### PR TITLE
Switched to Chart v3 Format - Chart Dependencies

### DIFF
--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -45,13 +45,12 @@ PATH=\\$$(dirname \\$$HELM):\\$$PATH
 #)
 
 # TODO(midnightconman): Add chart.yaml parameters and content option here
-def helm_package(name, templates, version = "0.0.0", requirements_yaml_content = ""):
-    # TODO(midnightconman): Add dependency chart inclusion here
+def helm_package(name, templates, chart_deps = "", version = "0.0.0"):
     """Defines a helm chart (directory containing a Chart.yaml).
 
     Args:
         name: A unique name for this rule.
-        requirements_yaml_content: A string (optional) that can be used to specify chart dependencies.
+        chart_deps: A string (optional) in yaml format that can be used to add remote chart dependencies.
         version: A string in semantic version format, to set as the charts version.
         templates: Source files to include as the helm chart. Typically this will just be glob(["**"]).
     """
@@ -67,7 +66,7 @@ def helm_package(name, templates, version = "0.0.0", requirements_yaml_content =
     native.genrule(
         name = name,
         srcs = [templates_filegroup_name],
-        outs = ["%s_chart.tar.gz" % name],
+        outs = ["%s-%s.tgz" % (name, version)],
         tools = ["@com_github_midnightconman_rules_helm//:helm"],
         # TODO(midnightconman): This should create a simple Chart.yaml if content is not provided
         cmd = """
@@ -80,15 +79,14 @@ mv $$TMP $(RULEDIR)
 echo "name: {name}
 version: {version}" > $(RULEDIR)/Chart.yaml
 
-# Write requirements.yaml
-echo "{requirements_yaml_content}" > $(RULEDIR)/requirements.yaml
+[[ ! -z "{chart_deps}" ]] && echo "dependencies:\n{chart_deps}" >> $(RULEDIR)/Chart.yaml
 
 $(location @com_github_midnightconman_rules_helm//:helm) package {package_flags} $(RULEDIR)
 mv *tgz $@
 """.format(
+            chart_deps = chart_deps,
             name = name,
             package_flags = package_flags,
-            requirements_yaml_content = requirements_yaml_content,
             version = version,
         ),
     )

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -45,12 +45,13 @@ PATH=\\$$(dirname \\$$HELM):\\$$PATH
 #)
 
 # TODO(midnightconman): Add chart.yaml parameters and content option here
+# TODO(midnightconman): Figure out a safe way to support chart dependencies
 def helm_package(name, templates, chart_deps = "", version = "0.0.0"):
     """Defines a helm chart (directory containing a Chart.yaml).
 
     Args:
         name: A unique name for this rule.
-        chart_deps: A string (optional) in yaml format that can be used to add remote chart dependencies.
+        chart_deps: A string (optional) in yaml format that can be used to add remote chart dependencies. Please note this option doesn't work correctly yet.
         version: A string in semantic version format, to set as the charts version.
         templates: Source files to include as the helm chart. Typically this will just be glob(["**"]).
     """


### PR DESCRIPTION
Helm v3 deprecated the `requirements.yaml` and moved to storing the chart dependencies in the Chart.yaml... this PR updates that process. Please note chart dependencies don't work yet, as helm won't package a chart unless all dependent charts are available in `/charts` -- dumb

If you try to use `chart_deps` you will get an error like this:
```
Error: found in Chart.yaml, but missing in charts/ directory: kyverno
```